### PR TITLE
Support overriding of CSRF header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # csrf-xhr
 
-Automatically add Rails CSRF tokens into XMLHttpRequest headers.
+Automatically add CSRF tokens into XMLHttpRequest headers.
+
+Supports Rails CSRF tokens with zero configuration, and can support other frameworks
+with an extra meta tag.
 
 ## How to Use
 
@@ -15,6 +18,16 @@ contents of the `<meta name="csrf-token">` that [Rails generates in the page's
 
 [jQuery-ujs](https://github.com/rails/jquery-ujs) does this for you;
 this does it for you even if you aren't using jQuery.
+
+#### Overriding CSRF Header Name
+
+An extra meta tag can be added to change the name of the CSRF header. For example, 
+Django uses the name `X-CSRFToken` instead of Rails' `X-CSRF-Token`. Django can be
+supported by adding:
+
+```html
+<meta name="csrf-header-name" content="X-CSRFToken">
+```
 
 ## Motivation
 

--- a/csrf-xhr.js
+++ b/csrf-xhr.js
@@ -27,6 +27,10 @@
     }
     
     var csrfToken = getMetaContent('csrf-token');
+    var csrfHeaderName = getMetaContent('csrf-header-name');
+    if (csrfHeaderName == null) {
+        csrfHeaderName = "X-CSRF-Token"; // Rails default
+    }
 
     // Patch XMLHttpRequest
     var originalOpen = xhr.open;
@@ -43,11 +47,11 @@
         var originalResult = originalOpen.apply(this, arguments);
 
         if (isLocalOrigin) {
-            // Set the X-CSRF-Token header, if possible.
+            // Set the token header, if possible.
             if (csrfToken === null) {
-                console.warn("csrf-xhr was unable to add a X-CSRF-Token header to a " + method + " to " + url + " because when csrf-xhr originally loaded, it could not find a <meta> element in the <head> with name=\"csrf-token\" and a Rails CSRF token in a content attribute.");
+                console.warn("csrf-xhr was unable to add a " + csrfHeaderName + " header to a " + method + " to " + url + " because when csrf-xhr originally loaded, it could not find a <meta> element in the <head> with name=\"csrf-token\" and a CSRF token in a content attribute.");
             } else {
-                this.setRequestHeader("X-CSRF-Token", csrfToken);
+                this.setRequestHeader(csrfHeaderName, csrfToken);
             }
         }
 

--- a/csrf-xhr.js
+++ b/csrf-xhr.js
@@ -9,20 +9,24 @@
     // available, to ensure consistency across browsers.
     var origin = location.protocol + "//" + location.hostname + (location.port ? ':' + location.port: '');
 
-    var csrfTokenNode, csrfToken;
+    function getMetaContent(name) {
+        var metaNode;
 
-    try {
-      csrfTokenNode = document.head.querySelector('meta[name="csrf-token"]');
-    } catch (e){
-      // ignore document-based errors
-      csrfTokenNode = null;
-    }
+        try {
+            metaNode = document.head.querySelector('meta[name="' + name + '"]');
+        } catch (e){
+            // ignore document-based errors
+            metaNode = null;
+        }
 
-    if ((csrfTokenNode !== null) && (typeof csrfTokenNode.content === "string")) {
-      csrfToken = csrfTokenNode.content;
-    } else {
-      csrfToken = null;
+        if ((metaNode !== null) && (typeof metaNode.content === "string")) {
+            return metaNode.content;
+        }
+
+        return null;
     }
+    
+    var csrfToken = getMetaContent('csrf-token');
 
     // Patch XMLHttpRequest
     var originalOpen = xhr.open;


### PR DESCRIPTION
Does what it says on the tin. Motivation is using this library with Django, which uses a different header name by default.

Let me know if you have any questions or feedback on the code, more than happy to change anything!
